### PR TITLE
add buf property

### DIFF
--- a/adafruit_pypixelbuf.py
+++ b/adafruit_pypixelbuf.py
@@ -95,6 +95,11 @@ class PixelBuf(object):  # pylint: disable=too-many-instance-attributes
             for i in range(0, self._pixels * 4, 4):
                 self._bytearray[i + self._offset] = DOTSTAR_LED_START_FULL_BRIGHT
 
+    @property
+    def buf(self):
+        return bytearray([int(i * self.brightness) for i in self._bytearray])
+
+
     @staticmethod
     def parse_byteorder(byteorder):
         """

--- a/adafruit_pypixelbuf.py
+++ b/adafruit_pypixelbuf.py
@@ -97,8 +97,8 @@ class PixelBuf(object):  # pylint: disable=too-many-instance-attributes
 
     @property
     def buf(self):
+        """The brightness adjusted pixel buffer data."""
         return bytearray([int(i * self.brightness) for i in self._bytearray])
-
 
     @staticmethod
     def parse_byteorder(byteorder):


### PR DESCRIPTION
To match the CircuitPython API:
https://circuitpython.readthedocs.io/en/latest/shared-bindings/_pixelbuf/PixelBuf.html#pixelbuf.PixelBuf.buf

Tested on RPi 3:
```python
(neopixel41) pi@raspberrypi:$ sudo python3
Python 3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import board, neopixel
>>> pixels = neopixel.NeoPixel(board.D18, 8, pixel_order="GRBW")
>>> pixels.fill(0xFF0000)
>>> pixels.show()
>>> pixels.brightness
1.0
>>> pixels.brightness = 0.1
>>> 
```