### PR TITLE
Fix dotstar brightness when setting with a tuple

### DIFF
--- a/adafruit_pypixelbuf.py
+++ b/adafruit_pypixelbuf.py
@@ -243,6 +243,7 @@ class PixelBuf:  # pylint: disable=too-many-instance-attributes
                 r, g, b, w = value
         elif len(value) == 3 and self._dotstar_mode:
             r, g, b = value
+            w = 1.0
 
         if self._bpp == 4 and self._dotstar_mode:
             # LED startframe is three "1" bits, followed by 5 brightness bits


### PR DESCRIPTION
Apologies for not catching this in the last PR, but I found a small bug in the new code where setting a DotStar with an RGB tuple would set the brightness to 0.