### PR TITLE
Allow setting RGBW pixels with RGB tuples

### DIFF
--- a/examples/pypixelbuf_simpletest.py
+++ b/examples/pypixelbuf_simpletest.py
@@ -4,7 +4,11 @@ import adafruit_pypixelbuf
 class TestBuf(adafruit_pypixelbuf.PixelBuf):
     called = False
 
-    def _transmit(self, buffer):
+    @property
+    def n(self):
+        return len(self)
+
+    def _transmit(self, buffer):  # pylint: disable=unused-argument
         self.called = True
 
 

--- a/examples/pypixelbuf_simpletest.py
+++ b/examples/pypixelbuf_simpletest.py
@@ -12,8 +12,10 @@ class TestBuf(adafruit_pypixelbuf.PixelBuf):
         self.called = True
 
 
-buf = TestBuf(20, "RGB", 1.0, auto_write=True)
+buf = TestBuf(20, "RGBW", 1.0, auto_write=True)
 buf[0] = (1, 2, 3)
+buf[1] = (1, 2, 3, 4)
+buf[2] = (2, 2, 2)
 
 print(buf[0])
 print(buf[0:2])


### PR DESCRIPTION
This change mirrors the change made in CP for pixelbuf [#2954](https://github.com/adafruit/circuitpython/pull/2954)