### PR TITLE
Set auto_write after brightness in init

### DIFF
--- a/adafruit_pypixelbuf.py
+++ b/adafruit_pypixelbuf.py
@@ -61,6 +61,8 @@ class PixelBuf:  # pylint: disable=too-many-instance-attributes
 
         bpp, byteorder_tuple, has_white, dotstar_mode = self.parse_byteorder(byteorder)
 
+        self.auto_write = False
+
         effective_bpp = 4 if dotstar_mode else bpp
         _bytes = effective_bpp * n
         buf = bytearray(_bytes)
@@ -89,8 +91,6 @@ class PixelBuf:  # pylint: disable=too-many-instance-attributes
         self._dotstar_mode = dotstar_mode
         self._pixel_step = effective_bpp
 
-        self.auto_write = auto_write
-
         if dotstar_mode:
             self._byteorder_tuple = (
                 byteorder_tuple[0] + 1,
@@ -101,6 +101,8 @@ class PixelBuf:  # pylint: disable=too-many-instance-attributes
 
         self._brightness = 1.0
         self.brightness = brightness
+
+        self.auto_write = auto_write
 
     @staticmethod
     def parse_byteorder(byteorder):

--- a/examples/pypixelbuf_simpletest.py
+++ b/examples/pypixelbuf_simpletest.py
@@ -12,7 +12,7 @@ class TestBuf(adafruit_pypixelbuf.PixelBuf):
         self.called = True
 
 
-buf = TestBuf(20, "RGBW", 1.0, auto_write=True)
+buf = TestBuf(20, "RGBW", brightness=0.5, auto_write=True)
 buf[0] = (1, 2, 3)
 buf[1] = (1, 2, 3, 4)
 buf[2] = (2, 2, 2)


### PR DESCRIPTION
This updates pypixelbuf to better match CP's pixelbuf. This also fixes https://github.com/adafruit/Adafruit_CircuitPython_NeoPixel/issues/85