### PR TITLE
Revert "Fix slice indices failure."

### DIFF
--- a/adafruit_pypixelbuf.py
+++ b/adafruit_pypixelbuf.py
@@ -289,9 +289,7 @@ class PixelBuf:  # pylint: disable=too-many-instance-attributes
 
     def __setitem__(self, index, val):
         if isinstance(index, slice):
-            start = index.start if index.start is not None else 0
-            stop = index.stop if index.stop is not None else len(self)
-            step = index.step if index.step is not None else 1
+            start, stop, step = index.indices(self._pixels)
             for val_i, in_i in enumerate(range(start, stop, step)):
                 r, g, b, w = self._parse_color(val[val_i])
                 self._set_item(in_i, r, g, b, w)


### PR DESCRIPTION
Now that indices are once again enabled in CP ([#4857](https://github.com/adafruit/circuitpython/pull/4857)), revert the changes from #31.

Tested with an itsybitsy M0.