### PR TITLE
Pypixelbuf: Delegate to _pixelbuf, make wheel() match it

### DIFF
--- a/adafruit_pypixelbuf.py
+++ b/adafruit_pypixelbuf.py
@@ -359,6 +359,12 @@ def colorwheel(pos):
     pos -= 170
     return pos * 3, 0, 255 - pos * 3
 
+# If _pypixelbuf is available, replace the content of this module
+# with the faster implementation from the core
+try:
+    from _pypixelbuf import *
+except ImportError:
+    pass
 
 # Use of wheel() is deprecated. Please use colorwheel().
 wheel = colorwheel

--- a/adafruit_pypixelbuf.py
+++ b/adafruit_pypixelbuf.py
@@ -350,14 +350,22 @@ def colorwheel(pos):
     # Input a value 0 to 255 to get a color value.
     # The colours are a transition r - g - b - back to r.
     if pos < 0 or pos > 255:
-        return 0, 0, 0
-    if pos < 85:
-        return 255 - pos * 3, pos * 3, 0
-    if pos < 170:
+        r = g = b = 0
+    elif pos < 85:
+        r = 255 - pos * 3
+        g = pos * 3
+        b = 0
+    elif pos < 170:
         pos -= 85
-        return 0, 255 - pos * 3, pos * 3
-    pos -= 170
-    return pos * 3, 0, 255 - pos * 3
+        r = 0
+        g = 255 - pos * 3
+        b = pos * 3
+    else:
+        pos -= 170
+        r = pos * 3
+        g = 0
+        b = 255 - pos * 3
+    return (r << 16) | (g << 8) | b
 
 # If _pypixelbuf is available, replace the content of this module
 # with the faster implementation from the core


### PR DESCRIPTION
In the weekly meeting, we discussed adafruit_pypixelbuf vs _pixelbuf.

I realized that we can put the responsibility of delegating to the C-coded routines in the Python module, rather than pushing it on to modules that want to USE the libraries, and implement that here.

I also changed wheel and colorwheel to return a color number instead of a tuple, because this is what _pixelbuf.colorwheel does and because it is likely to be a bit faster (as it avoids allocations)

I placed the aliasing of `wheel` to `colorwheel` after the import because I didn't know that the core module also had this alias.  It could be moved earlier, or (since it has been marked deprecated for a long time) it could be dropped and we could bump the major version number.