### PR TITLE
Silently remove wheel and colorwheel

### DIFF
--- a/adafruit_pypixelbuf.py
+++ b/adafruit_pypixelbuf.py
@@ -338,27 +338,3 @@ class PixelBuf:  # pylint: disable=too-many-instance-attributes
 
     def _transmit(self, buffer):
         raise NotImplementedError("Must be subclassed")
-
-
-def colorwheel(pos):
-    """
-    Helper to create a colorwheel.
-
-    :param pos: int 0-255 of color value to return
-    :return: tuple of RGB values
-    """
-    # Input a value 0 to 255 to get a color value.
-    # The colours are a transition r - g - b - back to r.
-    if pos < 0 or pos > 255:
-        return 0, 0, 0
-    if pos < 85:
-        return 255 - pos * 3, pos * 3, 0
-    if pos < 170:
-        pos -= 85
-        return 0, 255 - pos * 3, pos * 3
-    pos -= 170
-    return pos * 3, 0, 255 - pos * 3
-
-
-# Use of wheel() is deprecated. Please use colorwheel().
-wheel = colorwheel


### PR DESCRIPTION
If I understand correctly this will be moved to an independent library.
See https://github.com/adafruit/adafruit-circuitpython-weekly-meeting/blob/main/2021/2021-06-28.md

Maybe this need a version bump as an API change and/or some indication in the Readme for those that are currently using this and could be surprised. With indication of where is the new place or way to import colorwheel.